### PR TITLE
fix:  for deno version upgrade to 1.6 in guard

### DIFF
--- a/mod_test.tmpl-invalid-default-type.ts
+++ b/mod_test.tmpl-invalid-default-type.ts
@@ -4,7 +4,10 @@ export interface Content {
 }
 
 export function isValidContent(o: unknown): o is Content {
-  return o && typeof o === "object" && ("body" in o);
+  if (o && typeof o === "object") {
+    return "body" in o;
+  }
+  return false;
 }
 
 export function onInvalidContent(content: Content): string {

--- a/mod_test.tmpl-invalid-no-default.ts
+++ b/mod_test.tmpl-invalid-no-default.ts
@@ -4,7 +4,10 @@ export interface Content {
 }
 
 export function isValidContent(o: unknown): o is Content {
-  return o && typeof o === "object" && ("body" in o);
+  if (o && typeof o === "object") {
+    return "body" in o;
+  }
+  return false;
 }
 
 export function onInvalidContent(content: Content): string {

--- a/toctl.ts
+++ b/toctl.ts
@@ -9,6 +9,7 @@ import {
 import * as server from "./server.ts";
 import * as tm from "./template-module.ts";
 
+// deno-lint-ignore require-await
 export async function determineVersion(importMetaURL: string): Promise<string> {
   return gsv.determineVersionFromRepoTag(
     importMetaURL,
@@ -120,6 +121,7 @@ export async function transformStdInJsonHandler(
   }
 }
 
+// deno-lint-ignore require-await
 export async function validateConfigHandler(
   chc: CommandHandlerContext,
 ): Promise<true | void> {
@@ -273,6 +275,7 @@ export class CommandHandlerContext implements CommandHandlerContext {
   }
 }
 
+// deno-lint-ignore require-await
 export async function versionHandler(
   ctx: CommandHandlerContext,
 ): Promise<true | void> {


### PR DESCRIPTION
Updated the fix for deno v1.6 upgrade in the following files. 

- mod_test.tmpl-invalid-default-type.ts
- mod_test.tmpl-invalid-no-default.ts